### PR TITLE
Change the default behavior of `get_db_sqlite()` to use a `.db` file, rather than an in-memory database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.python-version
+main.py
+pyproject.toml
+pysky.db
+uv.lock

--- a/README.md
+++ b/README.md
@@ -373,10 +373,10 @@ See: https://docs.bsky.app/docs/advanced-guides/service-auth
 
 1. Clone the repo, add it to PYTHONPATH, pip install -r requirements.txt
 
-2. Set up a database connection. PostgreSQL and SQLite work, but other databases supported by the Peewee ORM should also work.
+2. (Optional) Set up a database connection. PostgreSQL and SQLite work, but other databases supported by the Peewee ORM should also work.
 
     * PostgreSQL: If the official PostgreSQL environment variables are set: (PGUSER, PGHOST, PGDATABASE, PGPASSWORD, optionally PGPORT) then that database will be used.
-    * SQLite: If those aren't set, the SQLite database `$BSKY_SQLITE_FILENAME` will be used. If that isn't set then ":memory:" will be used, an ephemeral in-memory database.
+    * SQLite: If those aren't set, the SQLite database `$BSKY_SQLITE_FILENAME` will be used. If that isn't set then a default filename of `pysky.db` in the current working directory will be used.
     * Alternatively, you can instantiate a Peewee database object yourself and pass it to the BskyClient constructor as `peewee_db` to override any database environment variables.
 
 3. Create database tables: run `./pysky/bin/create_tables.py`

--- a/pysky/database.py
+++ b/pysky/database.py
@@ -28,7 +28,7 @@ def get_db_postgresql():
 
 
 def get_db_sqlite():
-    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", ":memory:")
+    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", "pysky.db")
     return SqliteDatabase(sqlite_filename)
 
 


### PR DESCRIPTION
Hi, first off, thank you for this very useful library!

I ran into some errors when first getting this repo setup, and I'm wondering if this proposed change might make it easier for others to setup the library in the future.



<details>
  <summary>Specifically, here's the issue I ran into:</summary>

```
kyle@16:/Users/kyle/pysky$ uv run pysky/bin/create_tables.py
Creating missing tables: bsky_api_call_log, bsky_post, bsky_session, bsky_user_profile
kyle@16:/Users/kyle/pysky$ uv run main.py
Traceback (most recent call last):
  File "/Users/kyle/pysky/pysky/session.py", line 52, in get_did
    return self.did
           ^^^^^^^^
AttributeError: 'Session' object has no attribute 'did'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
sqlite3.OperationalError: no such table: bsky_session

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/Users/kyle/pysky/main.py", line 9, in <module>
    "repo": bsky.did,
            ^^^^^^^^
  File "/Users/kyle/pysky/pysky/client.py", line 75, in did
    return self.session.get_did(self)
           ~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/Users/kyle/pysky/pysky/session.py", line 54, in get_did
    self.load_or_create(client)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/kyle/pysky/pysky/session.py", line 68, in load_or_create
    session = self.load_serialized()
  File "/Users/kyle/pysky/pysky/session.py", line 130, in load_serialized
    BskySession.select()
    ~~~~~~~~~~~~~~~~~~~~
    .where(BskySession.exception.is_null())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    .where(BskySession.bsky_auth_username == self.bsky_auth_username)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    .order_by(BskySession.created_at.desc())[0]
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 2126, in __getitem__
    self._ensure_execution()
    ~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 2119, in _ensure_execution
    self.execute()
    ~~~~~~~~~~~~^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 2036, in inner
    return method(self, database, *args, **kwargs)
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 2107, in execute
    return self._execute(database)
           ~~~~~~~~~~~~~^^^^^^^^^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 2280, in _execute
    cursor = database.execute(self)
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 3330, in execute
    return self.execute_sql(sql, params)
           ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 3320, in execute_sql
    with __exception_wrapper__:
         ^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 3088, in __exit__
    reraise(new_type, new_type(exc_value, *exc_args), traceback)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 196, in reraise
    raise value.with_traceback(tb)
  File "/Users/kyle/pysky/.venv/lib/python3.13/site-packages/peewee.py", line 3322, in execute_sql
    cursor.execute(sql, params or ())
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
peewee.OperationalError: no such table: bsky_session
```

</details>

(Not sure if this is relevant, but I had initialized the client with `bsky = pysky.BskyClient(bsky_auth_username="assf.art", bsky_auth_password=<redacted>)`)

With this change made and after re-running `create_tables.py`, my script ran successfully. 