### PR TITLE
Attempt to automatically create non-existing tables on client initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,3 +169,8 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+.python-version
+main.py
+pyproject.toml
+pysky.db
+uv.lock

--- a/README.md
+++ b/README.md
@@ -373,15 +373,13 @@ See: https://docs.bsky.app/docs/advanced-guides/service-auth
 
 1. Clone the repo, add it to PYTHONPATH, pip install -r requirements.txt
 
-2. Set up a database connection. PostgreSQL and SQLite work, but other databases supported by the Peewee ORM should also work.
+2. (Optional) Set up a database connection. PostgreSQL and SQLite work, but other databases supported by the Peewee ORM should also work.
 
     * PostgreSQL: If the official PostgreSQL environment variables are set: (PGUSER, PGHOST, PGDATABASE, PGPASSWORD, optionally PGPORT) then that database will be used.
-    * SQLite: If those aren't set, the SQLite database `$BSKY_SQLITE_FILENAME` will be used. If that isn't set then ":memory:" will be used, an ephemeral in-memory database.
+    * SQLite: If those aren't set, the SQLite database `$BSKY_SQLITE_FILENAME` will be used. If that isn't set then a default filename of `pysky.db` in the current working directory will be used.
     * Alternatively, you can instantiate a Peewee database object yourself and pass it to the BskyClient constructor as `peewee_db` to override any database environment variables.
 
-3. Create database tables: run `./pysky/bin/create_tables.py`
-
-4. (Optional) Set authentication environment variables for username and app password: `BSKY_AUTH_USERNAME`, `BSKY_AUTH_PASSWORD`. If only public endpoints are going to be accessed, these aren't needed. Credentials can also be passed to the `BskyClient` constructor as `bsky_auth_username` and `bsky_auth_password`.
+3. (Optional) Set authentication environment variables for username and app password: `BSKY_AUTH_USERNAME`, `BSKY_AUTH_PASSWORD`. If only public endpoints are going to be accessed, these aren't needed. Credentials can also be passed to the `BskyClient` constructor as `bsky_auth_username` and `bsky_auth_password`.
 
 
 ## Tests

--- a/pysky/bin/create_tables.py
+++ b/pysky/bin/create_tables.py
@@ -20,7 +20,8 @@ def create_non_existing_tables(db):
     ]
 
     if not missing_table_model_classes:
-        print("All tables already exist.")
+        #print("All tables already exist.")
+        pass #removed print because this function is automatically called on initialization now
     else:
         print(
             f"Creating missing tables: {', '.join(str(cls._meta.table_name) for n,cls in missing_table_model_classes)}"

--- a/pysky/client.py
+++ b/pysky/client.py
@@ -65,6 +65,8 @@ class BskyClient:
             ), "peewee_db argument must be a subclass of peewee.Database"
             for subclass in [BaseModel] + BaseModel.__subclasses__():
                 subclass._meta.set_database(peewee_db)
+        
+        create_non_existing_tables(BskySession._meta.database)
 
     @property
     def auth_header(self):

--- a/pysky/database.py
+++ b/pysky/database.py
@@ -28,7 +28,7 @@ def get_db_postgresql():
 
 
 def get_db_sqlite():
-    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", ":memory:")
+    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", "pysky.db")
     return SqliteDatabase(sqlite_filename)
 
 

--- a/pysky/database.py
+++ b/pysky/database.py
@@ -28,7 +28,7 @@ def get_db_postgresql():
 
 
 def get_db_sqlite():
-    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", "pysky.db")
+    sqlite_filename = os.getenv("BSKY_SQLITE_FILENAME", ":memory:")
     return SqliteDatabase(sqlite_filename)
 
 


### PR DESCRIPTION
Hello again! 

The purpose of this PR is just to make the first usage of this library as painless as possible. I'd completely understand if you don't think this should be merged, it just a little change I thought might be nice, but it may run counter to how you think this library should be used.

Specifically, this change automatically runs `create_non_existing_tables()` during client initialization, rather than requiring the prerequisite step of running `pysky/bin/create_tables.py` before using this library. If it finds that the tables already exist, it silently continues. I also modified the README.md to reflect these changes.